### PR TITLE
fix: repoint 3 dead awesome-list presets to live repos (+ add awesome-ai-tools)

### DIFF
--- a/src/awesome/templates.js
+++ b/src/awesome/templates.js
@@ -5,7 +5,7 @@ import { utmUrl } from '../config.js';
 // Pre-configured awesome-list targets
 const TARGETS = {
   'chinese-independent-developer': {
-    repo: 'nichetools/chinese-independent-developer',
+    repo: '1c7/chinese-independent-developer',
     template: 'chinese',
   },
   'awesome-privacy': {
@@ -21,7 +21,7 @@ const TARGETS = {
     template: 'chinese',
   },
   'awesome-pwa': {
-    repo: 'nichetools/awesome-pwa',
+    repo: 'hemanth/awesome-pwa',
     template: 'english',
   },
   'awesome-indie': {
@@ -37,11 +37,15 @@ const TARGETS = {
     template: 'english',
   },
   'awesome-no-login-web-apps': {
-    repo: 'nichetools/awesome-no-login-web-apps',
+    repo: 'aviaryan/awesome-no-login-web-apps',
     template: 'english',
   },
   'awesome-astro': {
     repo: 'one-aalam/awesome-astro',
+    template: 'english',
+  },
+  'awesome-ai-tools': {
+    repo: 'mahseema/awesome-ai-tools',
     template: 'english',
   },
 };


### PR DESCRIPTION
Three `awesome` command presets in `src/awesome/templates.js` point to repos that 404, so `node src/cli.js awesome <key>` generated dead submission links:

| preset key | old repo (404) | fixed → live repo |
|---|---|---|
| `chinese-independent-developer` | `nichetools/chinese-independent-developer` | **`1c7/chinese-independent-developer`** (~49k⭐, the original) |
| `awesome-pwa` | `nichetools/awesome-pwa` | **`hemanth/awesome-pwa`** (~4.8k⭐) |
| `awesome-no-login-web-apps` | `nichetools/awesome-no-login-web-apps` | **`aviaryan/awesome-no-login-web-apps`** (~3.2k⭐, the original) |

All three `nichetools/*` repos return 404 via the GitHub API. The replacements are the canonical, actively-maintained lists in each niche (verified to exist with issues enabled).

Also added one new, relevant preset:
- `awesome-ai-tools` → `mahseema/awesome-ai-tools` (~5.4k⭐) — useful for AI products.

Single-file change, no behavior/format changes beyond the repo slugs. Verified each fixed preset now resolves to the correct `/issues/new` URL.