### PR TITLE
Add SaaSCity to overseas_directories

### DIFF
--- a/targets.yaml
+++ b/targets.yaml
@@ -993,7 +993,7 @@ overseas_directories:
     type: form
     auto: yes
     lang: en
-    notes: Gamified SaaS directory. DR 46, free listing, manually reviewed within 24h
+    notes: Gamified SaaS directory. DR 59, free listing, manually reviewed within 24h
 
   - name: Sitelike
     submit_url: https://www.sitelike.org/add-site

--- a/targets.yaml
+++ b/targets.yaml
@@ -988,6 +988,13 @@ overseas_general:
 # ============================================================
 overseas_directories:
 
+  - name: SaaSCity
+    submit_url: https://saascity.io/submit
+    type: form
+    auto: yes
+    lang: en
+    notes: Gamified SaaS directory. DR 46, free listing, manually reviewed within 24h
+
   - name: Sitelike
     submit_url: https://www.sitelike.org/add-site
     type: form


### PR DESCRIPTION
Adds **SaaSCity** to `targets.yaml` under `overseas_directories`.

```yaml
  - name: SaaSCity
    submit_url: https://saascity.io/submit
    type: form
    auto: yes
    lang: en
    notes: Gamified SaaS directory. DR 46, free listing, manually reviewed within 24h
```

- `type: form` — plain HTML form, no account required to start
- `auto: yes` — works with the generic adapter, no custom `src/sites/` file needed
- Free submission; paid tiers only add a dofollow link and map placement
- Ahrefs DR 46