### PR TITLE
Add Phyco to overseas_directories targets

### DIFF
--- a/targets.yaml
+++ b/targets.yaml
@@ -988,6 +988,13 @@ overseas_general:
 # ============================================================
 overseas_directories:
 
+  - name: Phyco
+    submit_url: https://phyco.org/submit
+    type: form
+    auto: yes
+    lang: en
+    notes: "Website catalogue with verified user reviews, 16 categories; free, no account, human moderation"
+
   - name: Sitelike
     submit_url: https://www.sitelike.org/add-site
     type: form


### PR DESCRIPTION
Adding [Phyco](https://phyco.org) to `overseas_directories` - a website catalogue with verified user reviews across 16 categories (AI, finance, design, utilities and more).

The submission form at https://phyco.org/submit is free, needs no account (only an unpublished contact email), and every submission is human-moderated, so `type: form`, `auto: yes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014aTConZcDTh57KMn39s5Xd